### PR TITLE
correct endpoint url in networkingV2Client for rackspace

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/terraform-providers/terraform-provider-openstack/openstack"
+	"github.com/kouk/terraform-provider-openstack/openstack"
 )
 
 func main() {

--- a/openstack/config.go
+++ b/openstack/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -257,10 +258,14 @@ func (c *Config) imageV2Client(region string) (*gophercloud.ServiceClient, error
 }
 
 func (c *Config) networkingV2Client(region string) (*gophercloud.ServiceClient, error) {
-	return openstack.NewNetworkV2(c.OsClient, gophercloud.EndpointOpts{
+	sc, err := openstack.NewNetworkV2(c.OsClient, gophercloud.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getEndpointType(),
 	})
+	if err == nil && strings.Contains(sc.Endpoint, "rackspacecloud") {
+		sc.ResourceBase = sc.Endpoint
+	}
+	return sc, err
 }
 
 func (c *Config) objectStorageV1Client(region string) (*gophercloud.ServiceClient, error) {


### PR DESCRIPTION
The gophercloud library adds the string `v2.0/` to the end of the endpoint URL without checking if that string is already present. In Rackspace, the service catalog already has the version in the URL so this results in `v2.0/v2.0` which leads to 404 Not Found:
https://github.com/kouk/terraform-provider-openstack/blob/da6bd01265bbcaeb5167b276fa360f6cde75390b/vendor/github.com/gophercloud/gophercloud/openstack/client.go#L324
